### PR TITLE
feat: implement starlinker backend skeleton

### DIFF
--- a/ForgeCore-main/ForgeCore-main/docs/STEP1_FOUNDATION.md
+++ b/ForgeCore-main/ForgeCore-main/docs/STEP1_FOUNDATION.md
@@ -1,0 +1,90 @@
+# Starlinker Foundational Planning
+
+## Baseline Assessment of ForgeCore
+- **Runtime orchestration**: `ForgeRuntime` wires together the event bus, capability registry, module loader, and storage manager, loading and enabling every discovered module from a target directory. "runtime" is started lazily and exposes lifecycle helpers via `create_runtime()`/`get_runtime()`. [Ref: `forgecore/runtime.py`]
+- **Admin HTTP surface**: The current `admin_api` builds a miniature FastAPI-compatible app using a local stub (`mini_fastapi`) and exposes module inventory plus storage CRUD endpoints. No Starlinker-specific routes exist yet. [Ref: `forgecore/admin_api.py`]
+- **Module system**: Module manifests follow the JSON schema outlined in `agent.md`, with loaders, capability graph validation, storage helpers, and a watcher for hot reloads already in place. [Refs: `forgecore/loader.py`, `forgecore/capabilities.py`, `forgecore/storage.py`, `forgecore/watcher.py`]
+- **Tooling & tests**: Pytest coverage exists for the runtime primitives (`event_bus`, `capabilities`, `loader`, `storage`, `admin_api`). Requirements target packaging/click/watchdog plus FastAPI/uvicorn in dev extras. No Starlinker packages, scheduler, or ingest pipelines are present yet. [Refs: `requirements.txt`, `setup.py`, `forgecore/tests/`]
+
+### Confirmed Tech Stack Versions
+- **Python**: Targeting 3.11 per product requirements; existing code is compatible with >=3.8 (no 3.11 blockers observed).
+- **Backend dependencies**: `fastapi>=0.68`, `uvicorn>=0.15`, `watchdog>=2.0`, `click>=8.0`, `packaging>=21` as per `requirements.txt`/`setup.py`. We will rely on the real FastAPI runtime (not the stub) for Starlinker APIs.
+- **Testing**: `pytest>=7.0` already configured. We will extend suites to cover scheduler logic, ingest normalization, and API contracts in later steps.
+- **Frontend/Electron**: No existing scaffold; we will introduce Node 18+/pnpm (or npm) alongside Electron 28+, React 18, and TailwindCSS 3 once we build the desktop shell in later steps.
+
+### Identified Gaps & Risks
+1. **Starlinker module absence**: `forgecore/starlinker_news/` does not exist—ingest, scheduler, alerts, digest, and API layers must be built from scratch.
+2. **HTTP stack**: The included `mini_fastapi` shim is insufficient for production. We need a full FastAPI/ASGI app (with uvicorn/Hypercorn runner) that can be invoked both standalone and via Electron.
+3. **Configuration**: No unified settings schema or persistence beyond generic storage. We must define Starlinker-specific keys, defaults, migrations, and validation.
+4. **Database**: Storage manager currently backs onto JSON files; we must add SQLite (via SQLAlchemy or `sqlite3`) with migrations to satisfy the required tables.
+5. **Scheduler**: No background job runner exists. We need an async scheduler (likely APScheduler) integrated with event bus and storage.
+6. **Packaging**: There is no Electron project, bundler config, or Windows packaging pipeline. Asset handling for the Fankit license is also missing.
+7. **Security & secrets**: No token storage/encryption helper exists. We must define a secrets vault or obfuscation strategy before wiring OAuth keys.
+
+## Architecture Blueprint (High-Level)
+```
++------------------+          HTTP/WebSocket           +-------------------------+
+|  Electron Main   |  ─────────────────────────────▶  |  FastAPI (Starlinker)   |
+|  • Single instance|                                   |  • Settings API         |
+|  • Tray menu     | ◀─────────────────────────────┐   |  • Scheduler control    |
+|  • Backend child |   Health / status polling     │   |  • Auth callbacks       |
++------------------+                               │   +-----------┬-------------+
+            │                                       │               │
+            │ IPC / preload                        │               │
+            ▼                                       │               ▼
++------------------+       REST/WS Queries         │     +---------------------+
+| Electron Renderer|  ─────────────────────────────┘     | Scheduler & Workers |
+|  • React Admin UI|                                         | • Priority polls |
+|  • Startup Wizard|                                         | • Standard polls |
++------------------+                                         | • Alert emission|
+            │                                              +---------┬-----------+
+            │                                                          │
+            ▼                                                          ▼
+    +---------------+        ORM/DAO Layer         +-----------------------------+
+    | SQLite (default) | ◀───────────────────────── |  Ingest Pipelines (RSI, YT) |
+    |  • settings      |                             |  • Normalizers             |
+    |  • signals       |                             |  • Tagger/Ranker           |
+    |  • alerts        |                             |  • Output dispatchers      |
+    +---------------+                             +-----------------------------+
+```
+
+## Configuration Strategy
+- **Format**: Adopt TOML (`starlinker.toml`) stored under the ForgeCore storage directory, synchronized with the SQLite `settings` table for durability. Electron renderer will use the API to read/write settings; CLI fallbacks will load from TOML on boot.
+- **Loader**: On startup, Starlinker module loads defaults, merges user overrides, and validates against Pydantic models. Changes persist to SQLite and mirror back to TOML.
+- **Secrets**: Sensitive values (webhooks, OAuth tokens) will be encrypted at rest using Fernet with a machine-local key; the config will store references while encrypted blobs live in SQLite.
+
+### Shared Settings Schema (Draft)
+```
+[starlinker.news]
+timezone = "America/New_York"
+quiet_hours = ["23:00", "07:00"]
+
+[starlinker.news.schedule]
+digest_daily = "09:00"
+digest_weekly = ""
+priority_poll_minutes = 60
+standard_poll_hours = 6
+
+[starlinker.news.outputs]
+discord_webhook = ""
+email_to = ""
+
+[starlinker.news.sources]
+patch_notes = { enabled = true, include_ptu = false }
+roadmap     = { enabled = true }
+status      = { enabled = true }
+this_week   = { enabled = true }
+inside_sc   = { enabled = true, channels = ["rsi_official"] }
+reddit      = { enabled = false, subs = ["starcitizen"], feed = ["new"], min_upvotes = 50 }
+
+[starlinker.news.appearance]
+theme = "neutral"  # options: neutral, uee, crusader, drake, rsi
+```
+This schema aligns with the product requirements and will be backed by migrations so future releases can evolve defaults safely.
+
+## Next Steps (Preview)
+1. **Backend Skeleton**: Create the `starlinker_news` package with FastAPI router, config loader, SQLite connection, and placeholder scheduler hooks.
+2. **Electron Bootstrap**: Scaffold the Electron app (main + renderer) with a splash screen and health-check polling against the backend.
+3. **Settings CRUD**: Implement read/write endpoints and React forms using the schema above, ensuring validation primitives are in place before wiring advanced features.
+
+These artifacts set the baseline so subsequent steps can focus on iterative feature delivery without architectural rework.

--- a/ForgeCore-main/ForgeCore-main/docs/STEP2_BACKEND_SKELETON.md
+++ b/ForgeCore-main/ForgeCore-main/docs/STEP2_BACKEND_SKELETON.md
@@ -1,0 +1,30 @@
+# Step 2 – Backend Skeleton
+
+This iteration brings the first runnable Starlinker-specific backend into the
+ForgeCore tree. The goal was to stand up persistent configuration, a concrete
+FastAPI surface, and the scaffolding for future schedulers/ingesters without yet
+implementing the heavy lifting.
+
+## Highlights
+
+- Added the `forgecore.starlinker_news` package with SQLite-backed persistence,
+  pydantic configuration models, and a FastAPI application factory.
+- Implemented a lightweight scheduler service that tracks manual poll/digest
+  triggers so the renderer can surface operational health immediately.
+- Exposed `/health`, `/settings`, `/run/poll`, `/run/digest`, and
+  `/appearance/themes` endpoints via FastAPI, providing the minimum contract the
+  forthcoming Electron shell and Admin UI can build against.
+- Provisioned the Starlinker schema tables (`signals`, `digests`, `alerts`,
+  `settings`, `errors`) and a `SettingsRepository` that persists config defaults
+  into SQLite on first boot.
+- Added unit tests exercising configuration persistence and the HTTP surface to
+  ensure the skeleton is stable for subsequent steps.
+
+## Next up
+
+- Flesh out the scheduler loop (priority vs. standard cadence) and connect real
+  ingest modules for the official RSI sources.
+- Expand the API with settings CRUD granularity, OAuth handshakes, and preview
+  endpoints required by the Startup Wizard/Admin UI.
+- Begin wiring the Electron main process to spawn this FastAPI backend and read
+  health/config state for the splash screen.

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/__init__.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/__init__.py
@@ -1,0 +1,7 @@
+"""Starlinker News backend package."""
+
+from .api import create_app
+from .backend import StarlinkerBackend
+from .config import StarlinkerConfig, THEME_SLUGS
+
+__all__ = ["create_app", "StarlinkerBackend", "StarlinkerConfig", "THEME_SLUGS"]

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/__main__.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/__main__.py
@@ -1,0 +1,44 @@
+"""Run the Starlinker backend skeleton with uvicorn."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+import uvicorn
+
+from .api import create_app
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Starlinker backend server")
+    parser.add_argument(
+        "--data-dir",
+        default=os.environ.get("STARLINKER_DATA", "./.starlinker"),
+        help="Directory where the SQLite database will be stored",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("STARLINKER_HOST", "127.0.0.1"),
+        help="Host interface for the API",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("PORT", "8777")),
+        help="TCP port for the API",
+    )
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    data_dir = Path(args.data_dir)
+    app = create_app(data_dir=data_dir)
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/api.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/api.py
@@ -1,0 +1,75 @@
+"""FastAPI application for the Starlinker backend skeleton."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+from .backend import StarlinkerBackend
+from .config import THEME_SLUGS, StarlinkerConfig
+
+
+class PollRequest(BaseModel):
+    reason: str = Field(default="manual", description="Reason for manual poll trigger")
+
+
+class DigestRequest(BaseModel):
+    type: str = Field(default="daily", description="Digest cadence to trigger")
+
+
+def create_app(
+    *,
+    backend: Optional[StarlinkerBackend] = None,
+    data_dir: Optional[str | Path] = None,
+) -> FastAPI:
+    """Create a configured FastAPI application."""
+
+    if backend is None:
+        target = Path(data_dir) if data_dir else Path.cwd() / "starlinker_data"
+        backend = StarlinkerBackend(target)
+
+    app = FastAPI(title="Starlinker News Backend", version="0.1.0")
+
+    @app.on_event("startup")
+    async def _startup() -> None:  # pragma: no cover - FastAPI lifecycle wrapper
+        backend.scheduler.start()
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:  # pragma: no cover - FastAPI lifecycle wrapper
+        backend.scheduler.stop()
+
+    @app.get("/health")
+    async def get_health() -> dict:
+        config = backend.load_config()
+        return {
+            "status": "ok",
+            "scheduler": backend.scheduler.describe(),
+            "storage": backend.database.health_snapshot(),
+            "missing": backend.missing_prerequisites(config),
+            "config": config.model_dump(),
+        }
+
+    @app.get("/settings", response_model=StarlinkerConfig)
+    async def get_settings() -> StarlinkerConfig:
+        return backend.load_config()
+
+    @app.put("/settings", response_model=StarlinkerConfig)
+    async def put_settings(config: StarlinkerConfig) -> StarlinkerConfig:
+        return backend.update_config(config)
+
+    @app.post("/run/poll")
+    async def run_poll(request: PollRequest) -> dict:
+        return backend.scheduler.trigger_poll(request.reason)
+
+    @app.post("/run/digest")
+    async def run_digest(request: DigestRequest) -> dict:
+        return backend.scheduler.trigger_digest(request.type)
+
+    @app.get("/appearance/themes")
+    async def list_themes() -> dict:
+        return {"themes": list(THEME_SLUGS)}
+
+    return app

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/backend.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/backend.py
@@ -1,0 +1,53 @@
+"""Core backend wiring for the Starlinker News module."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+from .config import StarlinkerConfig
+from .scheduler import HealthStatus, SchedulerService
+from .store import SettingsRepository, StarlinkerDatabase
+
+
+class StarlinkerBackend:
+    """Coordinates database, configuration and scheduler state."""
+
+    def __init__(
+        self,
+        data_dir: os.PathLike[str] | str,
+        *,
+        database_filename: str = "starlinker.db",
+    ) -> None:
+        base = Path(data_dir)
+        base.mkdir(parents=True, exist_ok=True)
+        self._db_path = base / database_filename
+        self.database = StarlinkerDatabase(self._db_path)
+        self.database.initialize()
+        self.settings = SettingsRepository(self.database)
+        self.health = HealthStatus()
+        config = self.settings.load()
+        self.scheduler = SchedulerService(self.settings, self.health)
+        self.scheduler.refresh_config(config)
+
+    @property
+    def data_dir(self) -> Path:
+        return self._db_path.parent
+
+    def load_config(self) -> StarlinkerConfig:
+        return self.settings.load()
+
+    def update_config(self, config: StarlinkerConfig) -> StarlinkerConfig:
+        stored = self.settings.save(config)
+        self.scheduler.refresh_config(stored)
+        return stored
+
+    def missing_prerequisites(self, config: Optional[StarlinkerConfig] = None) -> list[str]:
+        cfg = config or self.settings.load()
+        return self.settings.missing_prerequisites(cfg)
+
+    def create_app(self):  # pragma: no cover - thin wrapper
+        from .api import create_app
+
+        return create_app(backend=self)

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/config.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/config.py
@@ -1,0 +1,103 @@
+"""Configuration models and helpers for Starlinker."""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+THEME_SLUGS: Sequence[str] = ("neutral", "uee", "crusader", "drake", "rsi")
+
+
+class OutputsConfig(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
+    discord_webhook: str = ""
+    email_to: str = ""
+
+
+class PatchNotesConfig(BaseModel):
+    enabled: bool = True
+    include_ptu: bool = False
+
+
+class RoadmapConfig(BaseModel):
+    enabled: bool = True
+
+
+class StatusConfig(BaseModel):
+    enabled: bool = True
+
+
+class ThisWeekConfig(BaseModel):
+    enabled: bool = True
+
+
+class InsideStarCitizenConfig(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
+    enabled: bool = True
+    channels: List[str] = Field(default_factory=lambda: ["rsi_official"])
+
+
+class RedditSourceConfig(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
+    enabled: bool = False
+    subs: List[str] = Field(default_factory=lambda: ["starcitizen"])
+    feed: List[str] = Field(default_factory=lambda: ["new"])
+    min_upvotes: int = 50
+    include_keywords: List[str] = Field(default_factory=list)
+    exclude_keywords: List[str] = Field(default_factory=list)
+    exclude_flairs: List[str] = Field(default_factory=list)
+
+
+class SourcesConfig(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
+    patch_notes: PatchNotesConfig = PatchNotesConfig()
+    roadmap: RoadmapConfig = RoadmapConfig()
+    status: StatusConfig = StatusConfig()
+    this_week: ThisWeekConfig = ThisWeekConfig()
+    inside_sc: InsideStarCitizenConfig = InsideStarCitizenConfig()
+    reddit: RedditSourceConfig = RedditSourceConfig()
+
+
+class ScheduleConfig(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
+    digest_daily: str = "09:00"
+    digest_weekly: str = ""
+    priority_poll_minutes: int = 60
+    standard_poll_hours: int = 6
+
+
+class AppearanceConfig(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
+    theme: str = "neutral"
+
+    @field_validator("theme")
+    @classmethod
+    def validate_theme(cls, value: str) -> str:
+        if value not in THEME_SLUGS:
+            raise ValueError(f"theme '{value}' is not recognised")
+        return value
+
+
+class StarlinkerConfig(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
+    timezone: str = "America/New_York"
+    quiet_hours: List[str] = Field(default_factory=lambda: ["23:00", "07:00"])
+    schedule: ScheduleConfig = ScheduleConfig()
+    outputs: OutputsConfig = OutputsConfig()
+    sources: SourcesConfig = SourcesConfig()
+    appearance: AppearanceConfig = AppearanceConfig()
+
+    @field_validator("quiet_hours")
+    @classmethod
+    def validate_quiet_hours(cls, value: List[str]) -> List[str]:
+        if len(value) != 2:
+            raise ValueError("quiet_hours must define start and end")
+        return value

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/scheduler.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/scheduler.py
@@ -1,0 +1,100 @@
+"""Scheduler scaffolding for manual triggers and health reporting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Dict, Optional
+
+from .config import StarlinkerConfig
+
+
+def _iso(dt: Optional[datetime]) -> Optional[str]:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+@dataclass
+class HealthStatus:
+    """Tracks lightweight operational signals for the API."""
+
+    last_poll: Optional[datetime] = None
+    last_poll_reason: Optional[str] = None
+    last_digests: Dict[str, datetime] = field(default_factory=dict)
+    last_config: Optional[StarlinkerConfig] = None
+    running: bool = False
+    _lock: Lock = field(default_factory=Lock, init=False, repr=False)
+
+    def mark_started(self) -> None:
+        with self._lock:
+            self.running = True
+
+    def mark_stopped(self) -> None:
+        with self._lock:
+            self.running = False
+
+    def record_poll(self, when: datetime, reason: str) -> None:
+        with self._lock:
+            self.last_poll = when
+            self.last_poll_reason = reason
+
+    def record_digest(self, when: datetime, digest_type: str) -> None:
+        with self._lock:
+            self.last_digests[digest_type] = when
+
+    def update_config(self, config: StarlinkerConfig) -> None:
+        with self._lock:
+            self.last_config = config
+
+    def snapshot(self) -> Dict[str, Optional[str]]:
+        with self._lock:
+            return {
+                "running": self.running,
+                "last_poll": _iso(self.last_poll),
+                "last_poll_reason": self.last_poll_reason,
+                "last_digests": {k: _iso(v) for k, v in self.last_digests.items()},
+                "config": self.last_config.model_dump() if self.last_config else None,
+            }
+
+
+class SchedulerService:
+    """Placeholder scheduler for manual trigger endpoints."""
+
+    def __init__(self, settings_repo, health: Optional[HealthStatus] = None) -> None:
+        self._settings_repo = settings_repo
+        self._health = health or HealthStatus()
+        self._lock = Lock()
+
+    def start(self) -> None:
+        with self._lock:
+            self._health.mark_started()
+
+    def stop(self) -> None:
+        with self._lock:
+            self._health.mark_stopped()
+
+    def refresh_config(self, config: Optional[StarlinkerConfig] = None) -> StarlinkerConfig:
+        cfg = config or self._settings_repo.load()
+        self._health.update_config(cfg)
+        return cfg
+
+    def trigger_poll(self, reason: str = "manual") -> Dict[str, str]:
+        now = datetime.now(timezone.utc)
+        self._health.record_poll(now, reason)
+        return {"triggered_at": _iso(now), "reason": reason}
+
+    def trigger_digest(self, digest_type: str = "daily") -> Dict[str, str]:
+        now = datetime.now(timezone.utc)
+        self._health.record_digest(now, digest_type)
+        return {"triggered_at": _iso(now), "type": digest_type}
+
+    def describe(self) -> Dict[str, Optional[str]]:
+        return self._health.snapshot()
+
+    @property
+    def health(self) -> HealthStatus:
+        return self._health

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/store.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/store.py
@@ -1,0 +1,168 @@
+"""Persistence helpers for Starlinker."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from .config import StarlinkerConfig
+
+
+CREATE_STATEMENTS: Iterable[str] = (
+    """
+    CREATE TABLE IF NOT EXISTS signals (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        source TEXT NOT NULL,
+        title TEXT NOT NULL,
+        url TEXT NOT NULL,
+        published_at TEXT NOT NULL,
+        fetched_at TEXT NOT NULL,
+        raw_excerpt TEXT,
+        summary TEXT,
+        tags_json TEXT,
+        priority INTEGER
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS digests (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        sent_at TEXT NOT NULL,
+        type TEXT NOT NULL,
+        body_markdown TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS alerts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        created_at TEXT NOT NULL,
+        type TEXT NOT NULL,
+        title TEXT NOT NULL,
+        url TEXT,
+        delivered_channels_json TEXT,
+        dedup_key TEXT
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS settings (
+        key TEXT PRIMARY KEY,
+        value_json TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS errors (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        ts TEXT NOT NULL,
+        module TEXT NOT NULL,
+        message TEXT NOT NULL,
+        details_json TEXT
+    )
+    """,
+)
+
+
+@dataclass
+class StarlinkerDatabase:
+    """Lightweight SQLite wrapper used by the backend."""
+
+    path: Path
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def initialize(self) -> "StarlinkerDatabase":
+        with self.connect() as conn:
+            for statement in CREATE_STATEMENTS:
+                conn.execute(statement)
+            conn.commit()
+        return self
+
+    def get_setting(self, key: str, default: Optional[Any] = None) -> Any:
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT value_json FROM settings WHERE key = ?", (key,)
+            ).fetchone()
+            if not row:
+                return default
+            return json.loads(row["value_json"])
+
+    def put_setting(self, key: str, value: Any) -> None:
+        payload = json.dumps(value)
+        now = datetime.now(timezone.utc).isoformat()
+        with self.connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO settings(key, value_json, updated_at)
+                VALUES(?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    value_json=excluded.value_json,
+                    updated_at=excluded.updated_at
+                """,
+                (key, payload, now),
+            )
+            conn.commit()
+
+    def list_settings(self) -> Dict[str, Any]:
+        with self.connect() as conn:
+            cursor = conn.execute("SELECT key, value_json FROM settings")
+            return {row["key"]: json.loads(row["value_json"]) for row in cursor.fetchall()}
+
+    def health_snapshot(self) -> Dict[str, Any]:
+        with self.connect() as conn:
+            counts = {}
+            for table in ("signals", "digests", "alerts"):
+                counts[table] = conn.execute(
+                    f"SELECT COUNT(*) FROM {table}"
+                ).fetchone()[0]
+            error_row = conn.execute(
+                "SELECT module, message, ts FROM errors ORDER BY ts DESC LIMIT 1"
+            ).fetchone()
+        return {
+            "counts": counts,
+            "last_error": dict(error_row) if error_row else None,
+        }
+
+
+class SettingsRepository:
+    """Adapter to map settings records onto pydantic config models."""
+
+    SETTINGS_KEY = "starlinker.config"
+
+    def __init__(self, database: StarlinkerDatabase) -> None:
+        self.database = database
+        self.database.initialize()
+
+    def load(self) -> StarlinkerConfig:
+        raw = self.database.get_setting(self.SETTINGS_KEY)
+        if raw is None:
+            config = StarlinkerConfig()
+            self.save(config)
+            return config
+        return StarlinkerConfig.model_validate(raw)
+
+    def save(self, config: StarlinkerConfig) -> StarlinkerConfig:
+        payload = config.model_dump()
+        self.database.put_setting(self.SETTINGS_KEY, payload)
+        return config
+
+    def missing_prerequisites(self, config: Optional[StarlinkerConfig] = None) -> list[str]:
+        cfg = config or self.load()
+        missing: list[str] = []
+        if not cfg.outputs.discord_webhook and not cfg.outputs.email_to:
+            missing.append("digest_output")
+        if not cfg.timezone:
+            missing.append("timezone")
+        return missing
+
+    def export_raw(self) -> Dict[str, Any]:
+        return self.database.list_settings()

--- a/ForgeCore-main/ForgeCore-main/forgecore/tests/starlinker_news/test_api.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/tests/starlinker_news/test_api.py
@@ -1,0 +1,44 @@
+from fastapi.testclient import TestClient
+
+from forgecore.starlinker_news.api import create_app
+from forgecore.starlinker_news.backend import StarlinkerBackend
+
+
+def test_health_endpoint_reports_defaults(tmp_path):
+    backend = StarlinkerBackend(tmp_path)
+    app = create_app(backend=backend)
+    with TestClient(app) as client:
+        response = client.get("/health")
+        payload = response.json()
+
+    assert response.status_code == 200
+    assert payload["status"] == "ok"
+    assert payload["config"]["timezone"] == "America/New_York"
+    assert payload["scheduler"]["running"] is True
+
+
+def test_poll_endpoint_updates_health(tmp_path):
+    backend = StarlinkerBackend(tmp_path)
+    app = create_app(backend=backend)
+    with TestClient(app) as client:
+        poll_response = client.post("/run/poll", json={"reason": "test"})
+        assert poll_response.status_code == 200
+        health = client.get("/health").json()
+
+    assert health["scheduler"]["last_poll_reason"] == "test"
+    assert health["scheduler"]["last_poll"] is not None
+
+
+def test_settings_can_be_updated(tmp_path):
+    backend = StarlinkerBackend(tmp_path)
+    app = create_app(backend=backend)
+    with TestClient(app) as client:
+        current = client.get("/settings").json()
+        current["outputs"]["discord_webhook"] = "https://hooks.example"
+        update = client.put("/settings", json=current)
+        assert update.status_code == 200
+
+        refreshed = client.get("/settings").json()
+
+    assert refreshed["outputs"]["discord_webhook"] == "https://hooks.example"
+    assert backend.missing_prerequisites() == []

--- a/ForgeCore-main/ForgeCore-main/forgecore/tests/starlinker_news/test_config.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/tests/starlinker_news/test_config.py
@@ -1,0 +1,24 @@
+from forgecore.starlinker_news.config import StarlinkerConfig
+from forgecore.starlinker_news.store import SettingsRepository, StarlinkerDatabase
+
+
+def test_settings_repository_initialises_defaults(tmp_path):
+    db = StarlinkerDatabase(tmp_path / "starlinker.db")
+    repo = SettingsRepository(db)
+    config = repo.load()
+
+    assert isinstance(config, StarlinkerConfig)
+    assert config.outputs.discord_webhook == ""
+    assert repo.export_raw()[SettingsRepository.SETTINGS_KEY]["timezone"] == "America/New_York"
+
+
+def test_settings_repository_saves_and_reloads(tmp_path):
+    db = StarlinkerDatabase(tmp_path / "starlinker.db")
+    repo = SettingsRepository(db)
+    config = repo.load()
+    config.outputs.discord_webhook = "https://hooks.example"
+    repo.save(config)
+
+    reloaded = repo.load()
+    assert reloaded.outputs.discord_webhook == "https://hooks.example"
+    assert repo.missing_prerequisites(reloaded) == []

--- a/ForgeCore-main/ForgeCore-main/requirements.txt
+++ b/ForgeCore-main/ForgeCore-main/requirements.txt
@@ -1,6 +1,8 @@
 packaging>=21.0
 click>=8.0.0
 watchdog>=2.0.0
-fastapi>=0.68.0
-uvicorn>=0.15.0
+fastapi>=0.95.0
+uvicorn>=0.21.0
+pydantic>=1.10.0
+httpx>=0.24.1
 pytest>=7.0.0

--- a/ForgeCore-main/ForgeCore-main/setup.py
+++ b/ForgeCore-main/ForgeCore-main/setup.py
@@ -4,10 +4,22 @@ setup(
     name="forgecore-runtime",
     version="0.1.0",
     packages=find_packages(),
-    install_requires=["packaging>=21.0", "click>=8.0.0"],
+    install_requires=[
+        "packaging>=21.0",
+        "click>=8.0.0",
+        "watchdog>=2.0.0",
+        "fastapi>=0.95.0",
+        "uvicorn>=0.21.0",
+        "pydantic>=1.10.0",
+        "httpx>=0.24.1",
+    ],
     extras_require={
-        "watch": ["watchdog>=2.0.0"],
-        "dev": ["pytest>=7.0.0", "fastapi>=0.68.0", "uvicorn>=0.15.0"],
+        "dev": ["pytest>=7.0.0"],
     },
-    entry_points={"console_scripts": ["forge=forgecore.cli.forge:main"]},
+    entry_points={
+        "console_scripts": [
+            "forge=forgecore.cli.forge:main",
+            "starlinker-backend=forgecore.starlinker_news.__main__:main",
+        ]
+    },
 )


### PR DESCRIPTION
## Summary
- add the `starlinker_news` backend package with config models, SQLite persistence, scheduler scaffolding, and FastAPI endpoints
- document the Step 2 backend deliverable and expose a CLI entrypoint for running the service
- update runtime dependencies and add tests for configuration storage and API health/poll flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d03b864e94832eb9c018583683d1a1