### PR TITLE
Raise FastAPI and Pydantic minimum versions

### DIFF
--- a/ForgeCore-main/ForgeCore-main/requirements.txt
+++ b/ForgeCore-main/ForgeCore-main/requirements.txt
@@ -1,8 +1,8 @@
 packaging>=21.0
 click>=8.0.0
 watchdog>=2.0.0
-fastapi>=0.95.0
+fastapi>=0.103.0
 uvicorn>=0.21.0
-pydantic>=1.10.0
+pydantic>=2.0
 httpx>=0.24.1
 pytest>=7.0.0

--- a/ForgeCore-main/ForgeCore-main/setup.py
+++ b/ForgeCore-main/ForgeCore-main/setup.py
@@ -8,9 +8,9 @@ setup(
         "packaging>=21.0",
         "click>=8.0.0",
         "watchdog>=2.0.0",
-        "fastapi>=0.95.0",
+        "fastapi>=0.103.0",
         "uvicorn>=0.21.0",
-        "pydantic>=1.10.0",
+        "pydantic>=2.0",
         "httpx>=0.24.1",
     ],
     extras_require={


### PR DESCRIPTION
## Summary
- raise the FastAPI dependency floor to 0.103.0 to target the first release series compatible with Pydantic 2
- increase the minimum Pydantic requirement to 2.0 in both installation entry points

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08e350d0c832ebe65818738548d46