### PR TITLE
Implement Starlinker scheduler automation

### DIFF
--- a/ForgeCore-main/ForgeCore-main/docs/STEP2_BACKEND_SKELETON.md
+++ b/ForgeCore-main/ForgeCore-main/docs/STEP2_BACKEND_SKELETON.md
@@ -22,8 +22,8 @@ implementing the heavy lifting.
 
 ## Next up
 
-- Flesh out the scheduler loop (priority vs. standard cadence) and connect real
-  ingest modules for the official RSI sources.
+- Connect real ingest modules for the official RSI sources and plug them into
+  the scheduler's timed triggers.
 - Expand the API with settings CRUD granularity, OAuth handshakes, and preview
   endpoints required by the Startup Wizard/Admin UI.
 - Begin wiring the Electron main process to spawn this FastAPI backend and read

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/scheduler.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/scheduler.py
@@ -1,11 +1,13 @@
-"""Scheduler scaffolding for manual triggers and health reporting."""
+"""Scheduler implementation for manual triggers and timed automation."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from threading import Lock
-from typing import Dict, Optional
+from datetime import datetime, timedelta, timezone
+from threading import Event, Lock, Timer
+from typing import Callable, Dict, Optional
+
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from .config import StarlinkerConfig
 
@@ -16,6 +18,13 @@ def _iso(dt: Optional[datetime]) -> Optional[str]:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc).isoformat()
+
+
+def _resolve_timezone(name: str) -> ZoneInfo:
+    try:
+        return ZoneInfo(name)
+    except ZoneInfoNotFoundError:
+        return ZoneInfo("UTC")
 
 
 @dataclass
@@ -62,39 +71,219 @@ class HealthStatus:
 
 
 class SchedulerService:
-    """Placeholder scheduler for manual trigger endpoints."""
+    """Coordinates manual triggers with background scheduling."""
 
-    def __init__(self, settings_repo, health: Optional[HealthStatus] = None) -> None:
+    def __init__(
+        self,
+        settings_repo,
+        health: Optional[HealthStatus] = None,
+        *,
+        clock: Optional[Callable[[], datetime]] = None,
+        interval_scale: float = 1.0,
+    ) -> None:
         self._settings_repo = settings_repo
         self._health = health or HealthStatus()
         self._lock = Lock()
+        self._stop_event = Event()
+        self._timers: Dict[str, Timer] = {}
+        self._next_runs: Dict[str, datetime] = {}
+        self._config: Optional[StarlinkerConfig] = None
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._interval_scale = interval_scale
 
     def start(self) -> None:
         with self._lock:
+            if self._health.running:
+                return
+            self._stop_event.clear()
+            config = self._config or self._settings_repo.load()
+            self._config = config
             self._health.mark_started()
+            self._health.update_config(config)
+            self._schedule_from_config_locked()
 
     def stop(self) -> None:
         with self._lock:
+            if not self._health.running:
+                return
+            self._stop_event.set()
+            self._cancel_timers_locked()
             self._health.mark_stopped()
 
     def refresh_config(self, config: Optional[StarlinkerConfig] = None) -> StarlinkerConfig:
-        cfg = config or self._settings_repo.load()
-        self._health.update_config(cfg)
-        return cfg
+        with self._lock:
+            cfg = config or self._settings_repo.load()
+            self._config = cfg
+            self._health.update_config(cfg)
+            if self._health.running and not self._stop_event.is_set():
+                self._cancel_timers_locked()
+                self._schedule_from_config_locked()
+            return cfg
 
     def trigger_poll(self, reason: str = "manual") -> Dict[str, str]:
-        now = datetime.now(timezone.utc)
+        now = self._clock()
         self._health.record_poll(now, reason)
         return {"triggered_at": _iso(now), "reason": reason}
 
     def trigger_digest(self, digest_type: str = "daily") -> Dict[str, str]:
-        now = datetime.now(timezone.utc)
+        now = self._clock()
         self._health.record_digest(now, digest_type)
         return {"triggered_at": _iso(now), "type": digest_type}
 
     def describe(self) -> Dict[str, Optional[str]]:
-        return self._health.snapshot()
+        snapshot = self._health.snapshot()
+        with self._lock:
+            snapshot["next_runs"] = {k: _iso(v) for k, v in self._next_runs.items()}
+        return snapshot
 
     @property
     def health(self) -> HealthStatus:
         return self._health
+
+    # Internal helpers -------------------------------------------------
+
+    def _cancel_timers_locked(self) -> None:
+        for timer in self._timers.values():
+            timer.cancel()
+        self._timers.clear()
+        self._next_runs.clear()
+
+    def _schedule_from_config_locked(self) -> None:
+        if self._stop_event.is_set():
+            return
+        cfg = self._config or self._settings_repo.load()
+        schedule = cfg.schedule
+        self._schedule_poll_locked(
+            minutes=float(schedule.priority_poll_minutes),
+            reason="schedule:priority",
+            name="priority_poll",
+        )
+        self._schedule_poll_locked(
+            minutes=float(schedule.standard_poll_hours) * 60.0,
+            reason="schedule:standard",
+            name="standard_poll",
+        )
+        self._schedule_daily_digest_locked(cfg)
+        self._schedule_weekly_digest_locked(cfg)
+
+    def _register_timer_locked(
+        self, name: str, seconds: Optional[float], callback: Callable[[], None]
+    ) -> None:
+        existing = self._timers.pop(name, None)
+        if existing is not None:
+            existing.cancel()
+        if seconds is None or seconds <= 0 or self._stop_event.is_set():
+            self._next_runs.pop(name, None)
+            return
+        scaled = seconds * self._interval_scale
+        if scaled <= 0:
+            self._next_runs.pop(name, None)
+            return
+        run_at = self._clock() + timedelta(seconds=seconds)
+        self._next_runs[name] = run_at
+        timer = Timer(scaled, callback)
+        timer.daemon = True
+        self._timers[name] = timer
+        timer.start()
+
+    def _schedule_poll_locked(self, *, minutes: float, reason: str, name: str) -> None:
+        seconds = minutes * 60.0
+
+        def _callback() -> None:
+            if self._stop_event.is_set():
+                return
+            self.trigger_poll(reason)
+            with self._lock:
+                if self._stop_event.is_set():
+                    self._timers.pop(name, None)
+                    self._next_runs.pop(name, None)
+                    return
+                self._schedule_poll_locked(minutes=minutes, reason=reason, name=name)
+
+        self._register_timer_locked(name, seconds, _callback)
+
+    def _schedule_daily_digest_locked(
+        self, config: Optional[StarlinkerConfig] = None
+    ) -> None:
+        cfg = config or self._config or self._settings_repo.load()
+        seconds = self._seconds_until_daily(cfg)
+
+        def _callback() -> None:
+            if self._stop_event.is_set():
+                return
+            self.trigger_digest("daily")
+            with self._lock:
+                if self._stop_event.is_set():
+                    self._timers.pop("digest_daily", None)
+                    self._next_runs.pop("digest_daily", None)
+                    return
+                self._schedule_daily_digest_locked()
+
+        self._register_timer_locked("digest_daily", seconds, _callback)
+
+    def _schedule_weekly_digest_locked(
+        self, config: Optional[StarlinkerConfig] = None
+    ) -> None:
+        cfg = config or self._config or self._settings_repo.load()
+        seconds = self._seconds_until_weekly(cfg)
+
+        def _callback() -> None:
+            if self._stop_event.is_set():
+                return
+            self.trigger_digest("weekly")
+            with self._lock:
+                if self._stop_event.is_set():
+                    self._timers.pop("digest_weekly", None)
+                    self._next_runs.pop("digest_weekly", None)
+                    return
+                self._schedule_weekly_digest_locked()
+
+        self._register_timer_locked("digest_weekly", seconds, _callback)
+
+    def _seconds_until_daily(self, config: StarlinkerConfig) -> Optional[float]:
+        target = config.schedule.digest_daily.strip()
+        if not target:
+            return None
+        try:
+            hour, minute = (int(part) for part in target.split(":", 1))
+        except ValueError:
+            return None
+        tz = _resolve_timezone(config.timezone)
+        now_local = self._clock().astimezone(tz)
+        candidate = now_local.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        if candidate <= now_local:
+            candidate += timedelta(days=1)
+        return (candidate - now_local).total_seconds()
+
+    def _seconds_until_weekly(self, config: StarlinkerConfig) -> Optional[float]:
+        target = config.schedule.digest_weekly.strip()
+        if not target:
+            return None
+        parts = target.split()
+        if len(parts) != 2:
+            return None
+        day_raw, time_raw = parts
+        day_key = day_raw.lower()[:3]
+        weekdays = {
+            "mon": 0,
+            "tue": 1,
+            "wed": 2,
+            "thu": 3,
+            "fri": 4,
+            "sat": 5,
+            "sun": 6,
+        }
+        if day_key not in weekdays:
+            return None
+        try:
+            hour, minute = (int(part) for part in time_raw.split(":", 1))
+        except ValueError:
+            return None
+        tz = _resolve_timezone(config.timezone)
+        now_local = self._clock().astimezone(tz)
+        candidate = now_local.replace(hour=hour, minute=minute, second=0, microsecond=0)
+        day_offset = (weekdays[day_key] - now_local.weekday()) % 7
+        if day_offset == 0 and candidate <= now_local:
+            day_offset = 7
+        candidate += timedelta(days=day_offset)
+        return (candidate - now_local).total_seconds()

--- a/ForgeCore-main/ForgeCore-main/forgecore/tests/starlinker_news/test_scheduler.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/tests/starlinker_news/test_scheduler.py
@@ -1,0 +1,84 @@
+"""Tests for the Starlinker scheduler service."""
+
+from __future__ import annotations
+
+import time
+
+from forgecore.starlinker_news.scheduler import HealthStatus, SchedulerService
+from forgecore.starlinker_news.store import SettingsRepository, StarlinkerDatabase
+
+
+def _wait_for(predicate, *, timeout: float = 3.0, interval: float = 0.05) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+def test_scheduler_triggers_priority_poll_periodically(tmp_path) -> None:
+    database = StarlinkerDatabase(tmp_path / "starlinker.db")
+    settings = SettingsRepository(database)
+    config = settings.load()
+    config.schedule.priority_poll_minutes = 1
+    config.schedule.standard_poll_hours = 0
+    config.schedule.digest_daily = ""
+    config.schedule.digest_weekly = ""
+    settings.save(config)
+
+    scheduler = SchedulerService(
+        settings, HealthStatus(), interval_scale=0.01
+    )  # scale 1 minute -> ~0.6s for tests
+    try:
+        scheduler.start()
+        snapshot = scheduler.describe()
+        assert snapshot["running"] is True
+        assert "priority_poll" in snapshot["next_runs"]
+
+        triggered = _wait_for(
+            lambda: scheduler.describe()["last_poll_reason"] == "schedule:priority"
+        )
+        assert triggered, "priority poll was not triggered automatically"
+    finally:
+        scheduler.stop()
+
+
+def test_refresh_config_reschedules_priority_poll(tmp_path) -> None:
+    database = StarlinkerDatabase(tmp_path / "starlinker.db")
+    settings = SettingsRepository(database)
+    baseline = settings.load()
+    baseline.schedule.priority_poll_minutes = 1
+    baseline.schedule.standard_poll_hours = 0
+    settings.save(baseline)
+
+    scheduler = SchedulerService(settings, HealthStatus(), interval_scale=0.01)
+    try:
+        scheduler.start()
+        assert "priority_poll" in scheduler.describe()["next_runs"]
+
+        updated = baseline.model_copy()
+        updated.schedule.priority_poll_minutes = 0
+        settings.save(updated)
+        scheduler.refresh_config(updated)
+
+        assert "priority_poll" not in scheduler.describe()["next_runs"]
+    finally:
+        scheduler.stop()
+
+
+def test_scheduler_stop_clears_state(tmp_path) -> None:
+    database = StarlinkerDatabase(tmp_path / "starlinker.db")
+    settings = SettingsRepository(database)
+    config = settings.load()
+    config.schedule.priority_poll_minutes = 1
+    config.schedule.standard_poll_hours = 0
+    settings.save(config)
+
+    scheduler = SchedulerService(settings, HealthStatus(), interval_scale=0.01)
+    scheduler.start()
+    scheduler.stop()
+
+    snapshot = scheduler.describe()
+    assert snapshot["running"] is False
+    assert snapshot["next_runs"] == {}

--- a/ForgeCore-main/ForgeCore-main/requirements.txt
+++ b/ForgeCore-main/ForgeCore-main/requirements.txt
@@ -1,8 +1,8 @@
 packaging>=21.0
 click>=8.0.0
 watchdog>=2.0.0
-fastapi>=0.95.0
+fastapi>=0.103.0
 uvicorn>=0.21.0
-pydantic>=1.10.0
+pydantic>=2.0
 httpx>=0.24.1
 pytest>=7.0.0

--- a/ForgeCore-main/ForgeCore-main/setup.py
+++ b/ForgeCore-main/ForgeCore-main/setup.py
@@ -8,9 +8,9 @@ setup(
         "packaging>=21.0",
         "click>=8.0.0",
         "watchdog>=2.0.0",
-        "fastapi>=0.95.0",
+        "fastapi>=0.103.0",
         "uvicorn>=0.21.0",
-        "pydantic>=1.10.0",
+        "pydantic>=2.0",
         "httpx>=0.24.1",
     ],
     extras_require={


### PR DESCRIPTION
## Summary
- extend the Starlinker scheduler with background timers, timezone-aware digest scheduling, and next-run health reporting to remove the placeholder implementation
- add targeted tests for periodic polling, configuration refresh, and shutdown behaviour of the scheduler with a scale knob for fast execution
- refresh the Step 2 roadmap to direct Phase 3 work toward wiring real ingesters into the automated scheduler

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08e350d0c832ebe65818738548d46