### PR TITLE
Update scheduler highlight in backend skeleton docs

### DIFF
--- a/ForgeCore-main/ForgeCore-main/docs/STEP2_BACKEND_SKELETON.md
+++ b/ForgeCore-main/ForgeCore-main/docs/STEP2_BACKEND_SKELETON.md
@@ -9,8 +9,9 @@ implementing the heavy lifting.
 
 - Added the `forgecore.starlinker_news` package with SQLite-backed persistence,
   pydantic configuration models, and a FastAPI application factory.
-- Implemented a lightweight scheduler service that tracks manual poll/digest
-  triggers so the renderer can surface operational health immediately.
+- Implemented a scheduler service with background timers that drive
+  timezone-aware digests, surface detailed health reporting, and extend the
+  manual trigger tracking with new regression tests.
 - Exposed `/health`, `/settings`, `/run/poll`, `/run/digest`, and
   `/appearance/themes` endpoints via FastAPI, providing the minimum contract the
   forthcoming Electron shell and Admin UI can build against.


### PR DESCRIPTION
## Summary
- update the scheduler highlight in the Step 2 backend skeleton doc to reflect background timers, timezone-aware digests, health reporting, and new regression coverage

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d096658d50832e95deda2641e5107a