### PR TITLE
Wire renderer settings editor to Starlinker backend

### DIFF
--- a/ForgeCore-main/ForgeCore-main/electron/renderer/src/components/SettingsEditor.tsx
+++ b/ForgeCore-main/ForgeCore-main/electron/renderer/src/components/SettingsEditor.tsx
@@ -1,0 +1,160 @@
+import { FormEvent, useEffect, useMemo } from 'react';
+import { formatIsoTimestamp } from '../lib/formatIsoTimestamp';
+import { useSettingsStore } from '../state/settingsStore';
+
+const STATUS_LABELS: Record<string, string> = {
+  idle: 'Idle',
+  loading: 'Loading…',
+  ready: 'Ready',
+  saving: 'Saving…',
+  error: 'Error',
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  idle: 'bg-slate-600/30 text-slate-200',
+  loading: 'bg-amber-500/20 text-amber-200',
+  ready: 'bg-emerald-500/20 text-emerald-300',
+  saving: 'bg-amber-500/20 text-amber-200',
+  error: 'bg-rose-500/20 text-rose-200',
+};
+
+export function SettingsEditor() {
+  const status = useSettingsStore((state) => state.status);
+  const error = useSettingsStore((state) => state.error);
+  const draft = useSettingsStore((state) => state.draft);
+  const validationIssues = useSettingsStore((state) => state.validationIssues);
+  const lastLoaded = useSettingsStore((state) => state.lastLoaded);
+  const lastSaved = useSettingsStore((state) => state.lastSaved);
+  const setDraft = useSettingsStore((state) => state.setDraft);
+  const resetDraft = useSettingsStore((state) => state.resetDraft);
+  const applyDefaultsToDraft = useSettingsStore((state) => state.applyDefaultsToDraft);
+  const loadSettings = useSettingsStore((state) => state.loadSettings);
+  const saveDraft = useSettingsStore((state) => state.saveDraft);
+  const hasDefaults = useSettingsStore((state) => state.defaults !== null);
+
+  useEffect(() => {
+    if (status === 'idle') {
+      void loadSettings();
+    }
+  }, [status, loadSettings]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await saveDraft();
+  };
+
+  const statusBadge = useMemo(() => {
+    const label = STATUS_LABELS[status] ?? status;
+    const style = STATUS_STYLES[status] ?? STATUS_STYLES.idle;
+    return (
+      <span className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${style}`}>
+        {label}
+      </span>
+    );
+  }, [status]);
+
+  const isBusy = status === 'loading' || status === 'saving';
+
+  return (
+    <article className="flex h-full flex-col rounded-xl border border-slate-800/70 bg-slate-900/40 p-5 shadow-lg shadow-slate-950/40">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-medium text-slate-100">Settings</h2>
+        {statusBadge}
+      </div>
+      <p className="mt-3 text-sm text-slate-400">
+        Review the Starlinker configuration loaded from FastAPI. Adjust values using the JSON editor and save
+        directly to the backend, or revert to the persisted settings.
+      </p>
+
+      <form className="mt-4 flex flex-1 flex-col space-y-4" onSubmit={handleSubmit}>
+        <div className="flex-1">
+          <label className="text-xs font-semibold uppercase tracking-wide text-slate-400">Configuration JSON</label>
+          <textarea
+            className="mt-2 h-64 w-full rounded-lg border border-slate-800 bg-slate-950/70 p-3 font-mono text-xs text-slate-100 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500/30 disabled:cursor-wait disabled:opacity-60"
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            spellCheck={false}
+            disabled={isBusy}
+          />
+        </div>
+
+        {error ? (
+          <div className="rounded-lg border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-200">
+            {error}
+          </div>
+        ) : null}
+
+        {validationIssues.length > 0 ? (
+          <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-100">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-amber-300">Validation Issues</h3>
+            <ul className="mt-2 space-y-1">
+              {validationIssues.map((issue, index) => (
+                <li key={`${issue.loc.join('.')}-${index}`} className="flex flex-col">
+                  <span className="text-xs font-medium text-amber-200">
+                    {issue.loc.length > 0 ? issue.loc.join(' › ') : 'root'}
+                  </span>
+                  <span className="text-amber-100">{issue.msg}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="submit"
+            className="inline-flex items-center justify-center rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-700 disabled:cursor-not-allowed disabled:bg-slate-700"
+            disabled={isBusy}
+          >
+            {status === 'saving' ? 'Saving…' : 'Save Settings'}
+          </button>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-lg border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-slate-500 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={resetDraft}
+            disabled={isBusy}
+          >
+            Revert to Saved
+          </button>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-lg border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-slate-500 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={applyDefaultsToDraft}
+            disabled={isBusy || !hasDefaults}
+          >
+            Load Defaults
+          </button>
+        </div>
+      </form>
+
+      <footer className="mt-4 space-y-1 text-xs text-slate-500">
+        <p>Last loaded: {formatIsoTimestamp(lastLoaded)}</p>
+        <p>Last saved: {formatIsoTimestamp(lastSaved)}</p>
+      </footer>
+
+      <details className="mt-4 rounded-lg border border-slate-800/70 bg-slate-950/40 p-3 text-sm text-slate-300">
+        <summary className="cursor-pointer text-sm font-medium text-slate-200">Schema Preview</summary>
+        <SchemaPreview />
+      </details>
+    </article>
+  );
+}
+
+function SchemaPreview() {
+  const schema = useSettingsStore((state) => state.schema);
+  const status = useSettingsStore((state) => state.status);
+
+  if (status === 'loading' && !schema) {
+    return <p className="mt-2 text-xs text-slate-500">Loading schema…</p>;
+  }
+
+  if (!schema) {
+    return <p className="mt-2 text-xs text-slate-500">Schema unavailable.</p>;
+  }
+
+  return (
+    <pre className="mt-2 max-h-48 overflow-auto rounded bg-slate-950/80 p-3 text-xs text-slate-200">
+      {JSON.stringify(schema, null, 2)}
+    </pre>
+  );
+}

--- a/ForgeCore-main/ForgeCore-main/electron/renderer/src/lib/formatIsoTimestamp.ts
+++ b/ForgeCore-main/ForgeCore-main/electron/renderer/src/lib/formatIsoTimestamp.ts
@@ -1,0 +1,12 @@
+export function formatIsoTimestamp(iso?: string, fallback = 'Never'): string {
+  if (!iso) {
+    return fallback;
+  }
+
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return fallback;
+  }
+
+  return date.toLocaleString();
+}

--- a/ForgeCore-main/ForgeCore-main/electron/renderer/src/pages/Dashboard.tsx
+++ b/ForgeCore-main/ForgeCore-main/electron/renderer/src/pages/Dashboard.tsx
@@ -1,18 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAppStore } from '../state/appStore';
 import { getApiBaseUrl } from '../lib/getApiBaseUrl';
+import { formatIsoTimestamp } from '../lib/formatIsoTimestamp';
+import { SettingsEditor } from '../components/SettingsEditor';
 
 type HealthResponse = {
   status?: string;
   version?: string;
-};
-
-const formatTimestamp = (iso?: string) => {
-  if (!iso) {
-    return 'Never';
-  }
-  const date = new Date(iso);
-  return date.toLocaleString();
 };
 
 export function Dashboard() {
@@ -104,7 +98,7 @@ export function Dashboard() {
           <dl className="mt-4 space-y-3 text-sm text-slate-300">
             <div className="flex justify-between">
               <dt className="text-slate-400">Last Checked</dt>
-              <dd className="font-medium text-slate-100">{formatTimestamp(backendHealth.lastChecked)}</dd>
+              <dd className="font-medium text-slate-100">{formatIsoTimestamp(backendHealth.lastChecked)}</dd>
             </div>
             <div className="flex justify-between">
               <dt className="text-slate-400">Message</dt>
@@ -132,27 +126,7 @@ export function Dashboard() {
           </button>
         </article>
 
-        <article className="rounded-xl border border-slate-800/70 bg-slate-900/40 p-5 shadow-lg shadow-slate-950/40">
-          <h2 className="text-lg font-medium text-slate-100">Next Steps</h2>
-          <p className="mt-3 text-sm text-slate-400">
-            This dashboard shell is wired to the FastAPI backend. Upcoming milestones will flesh out settings
-            management, ingest scheduling, and alerting workflows.
-          </p>
-          <ul className="mt-4 space-y-2 text-sm text-slate-300">
-            <li className="flex items-center gap-2">
-              <span className="h-2 w-2 rounded-full bg-brand-500" aria-hidden="true" />
-              Configure shared settings surface
-            </li>
-            <li className="flex items-center gap-2">
-              <span className="h-2 w-2 rounded-full bg-brand-500" aria-hidden="true" />
-              Implement scheduler insights and ingest stats
-            </li>
-            <li className="flex items-center gap-2">
-              <span className="h-2 w-2 rounded-full bg-brand-500" aria-hidden="true" />
-              Add alerting, digest, and connection management tabs
-            </li>
-          </ul>
-        </article>
+        <SettingsEditor />
       </section>
     </div>
   );

--- a/ForgeCore-main/ForgeCore-main/electron/renderer/src/state/settingsStore.ts
+++ b/ForgeCore-main/ForgeCore-main/electron/renderer/src/state/settingsStore.ts
@@ -1,0 +1,203 @@
+import { create } from 'zustand';
+import { getApiBaseUrl } from '../lib/getApiBaseUrl';
+import type { SettingsSchema, StarlinkerConfig, ValidationIssue } from '../types/settings';
+
+type SettingsStatus = 'idle' | 'loading' | 'ready' | 'saving' | 'error';
+
+type SettingsState = {
+  config: StarlinkerConfig | null;
+  defaults: StarlinkerConfig | null;
+  schema: SettingsSchema | null;
+  status: SettingsStatus;
+  error?: string;
+  draft: string;
+  validationIssues: ValidationIssue[];
+  lastLoaded?: string;
+  lastSaved?: string;
+  loadSettings: () => Promise<void>;
+  setDraft: (draft: string) => void;
+  resetDraft: () => void;
+  applyDefaultsToDraft: () => void;
+  saveDraft: () => Promise<boolean>;
+};
+
+function toValidationIssues(payload: unknown): ValidationIssue[] {
+  if (!Array.isArray(payload)) {
+    return [];
+  }
+
+  return payload
+    .map((item) => {
+      if (item && typeof item === 'object') {
+        const loc = Array.isArray((item as { loc?: unknown }).loc)
+          ? ((item as { loc: unknown[] }).loc.map((segment) => String(segment)))
+          : [];
+        const msg = typeof (item as { msg?: unknown }).msg === 'string'
+          ? ((item as { msg: string }).msg)
+          : 'Invalid value';
+        const type = typeof (item as { type?: unknown }).type === 'string'
+          ? ((item as { type: string }).type)
+          : undefined;
+        return { loc, msg, type } satisfies ValidationIssue;
+      }
+      return null;
+    })
+    .filter((entry): entry is ValidationIssue => Boolean(entry));
+}
+
+export const useSettingsStore = create<SettingsState>((set, get) => ({
+  config: null,
+  defaults: null,
+  schema: null,
+  status: 'idle',
+  error: undefined,
+  draft: '',
+  validationIssues: [],
+  lastLoaded: undefined,
+  lastSaved: undefined,
+
+  loadSettings: async () => {
+    const currentStatus = get().status;
+    if (currentStatus === 'loading') {
+      return;
+    }
+
+    const base = getApiBaseUrl();
+    set({ status: 'loading', error: undefined });
+
+    try {
+      const [configRes, defaultsRes, schemaRes] = await Promise.all([
+        fetch(`${base}/settings`),
+        fetch(`${base}/settings/defaults`),
+        fetch(`${base}/settings/schema`),
+      ]);
+
+      if (!configRes.ok) {
+        throw new Error(`Failed to load settings (HTTP ${configRes.status})`);
+      }
+      if (!defaultsRes.ok) {
+        throw new Error(`Failed to load defaults (HTTP ${defaultsRes.status})`);
+      }
+      if (!schemaRes.ok) {
+        throw new Error(`Failed to load schema (HTTP ${schemaRes.status})`);
+      }
+
+      const [config, defaults, schema] = await Promise.all<[
+        StarlinkerConfig,
+        StarlinkerConfig,
+        SettingsSchema,
+      ]>([
+        configRes.json(),
+        defaultsRes.json(),
+        schemaRes.json(),
+      ]);
+
+      const now = new Date().toISOString();
+      set({
+        config,
+        defaults,
+        schema,
+        status: 'ready',
+        draft: JSON.stringify(config, null, 2),
+        validationIssues: [],
+        error: undefined,
+        lastLoaded: now,
+      });
+    } catch (error) {
+      set({
+        status: 'error',
+        error: error instanceof Error ? error.message : 'Unable to load settings',
+      });
+    }
+  },
+
+  setDraft: (draft) => set({ draft }),
+
+  resetDraft: () => {
+    const config = get().config;
+    if (config) {
+      set({
+        draft: JSON.stringify(config, null, 2),
+        validationIssues: [],
+        error: undefined,
+      });
+    }
+  },
+
+  applyDefaultsToDraft: () => {
+    const defaults = get().defaults;
+    if (defaults) {
+      set({
+        draft: JSON.stringify(defaults, null, 2),
+        validationIssues: [],
+        error: undefined,
+      });
+    }
+  },
+
+  saveDraft: async () => {
+    const { draft } = get();
+    let payload: unknown;
+    try {
+      payload = JSON.parse(draft);
+    } catch (error) {
+      set({
+        error: error instanceof Error ? `Invalid JSON: ${error.message}` : 'Invalid JSON payload',
+        validationIssues: [],
+        status: 'ready',
+      });
+      return false;
+    }
+
+    const base = getApiBaseUrl();
+    set({ status: 'saving', error: undefined, validationIssues: [] });
+
+    try {
+      const response = await fetch(`${base}/settings`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const body = await response.json().catch(() => undefined);
+
+      if (response.status === 422) {
+        const detail =
+          body && typeof body === 'object' && 'detail' in body
+            ? (body as { detail: unknown }).detail
+            : body;
+        const validationIssues = toValidationIssues(detail);
+        set({
+          status: 'ready',
+          error: 'Validation failed. Please review the highlighted issues.',
+          validationIssues,
+        });
+        return false;
+      }
+
+      if (!response.ok) {
+        throw new Error(`Failed to save settings (HTTP ${response.status})`);
+      }
+
+      const updated = body as StarlinkerConfig;
+      const now = new Date().toISOString();
+      set({
+        config: updated,
+        draft: JSON.stringify(updated, null, 2),
+        status: 'ready',
+        validationIssues: [],
+        error: undefined,
+        lastSaved: now,
+      });
+      return true;
+    } catch (error) {
+      set({
+        status: 'ready',
+        error: error instanceof Error ? error.message : 'Unable to save settings',
+      });
+      return false;
+    }
+  },
+}));

--- a/ForgeCore-main/ForgeCore-main/electron/renderer/src/types/settings.ts
+++ b/ForgeCore-main/ForgeCore-main/electron/renderer/src/types/settings.ts
@@ -1,0 +1,75 @@
+export type QuietHourRange = [string, string];
+
+export interface OutputsConfig {
+  discord_webhook: string;
+  email_to: string;
+}
+
+export interface PatchNotesConfig {
+  enabled: boolean;
+  include_ptu: boolean;
+}
+
+export interface RoadmapConfig {
+  enabled: boolean;
+}
+
+export interface StatusConfig {
+  enabled: boolean;
+}
+
+export interface ThisWeekConfig {
+  enabled: boolean;
+}
+
+export interface InsideStarCitizenConfig {
+  enabled: boolean;
+  channels: string[];
+}
+
+export interface RedditSourceConfig {
+  enabled: boolean;
+  subs: string[];
+  feed: string[];
+  min_upvotes: number;
+  include_keywords: string[];
+  exclude_keywords: string[];
+  exclude_flairs: string[];
+}
+
+export interface SourcesConfig {
+  patch_notes: PatchNotesConfig;
+  roadmap: RoadmapConfig;
+  status: StatusConfig;
+  this_week: ThisWeekConfig;
+  inside_sc: InsideStarCitizenConfig;
+  reddit: RedditSourceConfig;
+}
+
+export interface ScheduleConfig {
+  digest_daily: string;
+  digest_weekly: string;
+  priority_poll_minutes: number;
+  standard_poll_hours: number;
+}
+
+export interface AppearanceConfig {
+  theme: string;
+}
+
+export interface StarlinkerConfig {
+  timezone: string;
+  quiet_hours: QuietHourRange;
+  schedule: ScheduleConfig;
+  outputs: OutputsConfig;
+  sources: SourcesConfig;
+  appearance: AppearanceConfig;
+}
+
+export interface ValidationIssue {
+  loc: string[];
+  msg: string;
+  type?: string;
+}
+
+export type SettingsSchema = Record<string, unknown>;

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/backend.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/backend.py
@@ -6,6 +6,9 @@ import os
 from pathlib import Path
 from typing import Optional
 
+from collections.abc import Mapping
+from typing import Any
+
 from .config import StarlinkerConfig
 from .scheduler import HealthStatus, SchedulerService
 from .store import SettingsRepository, StarlinkerDatabase
@@ -42,6 +45,17 @@ class StarlinkerBackend:
         stored = self.settings.save(config)
         self.scheduler.refresh_config(stored)
         return stored
+
+    def patch_config(self, patch: Mapping[str, Any]) -> StarlinkerConfig:
+        stored = self.settings.apply_patch(patch)
+        self.scheduler.refresh_config(stored)
+        return stored
+
+    def default_config(self) -> StarlinkerConfig:
+        return self.settings.default_config()
+
+    def config_schema(self) -> dict[str, object]:
+        return self.settings.config_schema()
 
     def missing_prerequisites(self, config: Optional[StarlinkerConfig] = None) -> list[str]:
         cfg = config or self.settings.load()


### PR DESCRIPTION
## Summary
- add a Zustand-powered settings store that loads defaults/schema, manages a JSON draft, and persists Starlinker config updates with validation feedback
- replace the dashboard placeholder with a Settings editor card wired to the backend, including schema preview and timestamp badges
- share an ISO timestamp formatter utility for both the dashboard and settings views

## Testing
- pytest forgecore/tests/starlinker_news/test_api.py
- npm run build --prefix ForgeCore-main/ForgeCore-main/electron/renderer


------
https://chatgpt.com/codex/tasks/task_e_68ddd5b17a38832e9730a7da86f23ded