### PR TITLE
Fix wizard save recovery state

### DIFF
--- a/ForgeCore-main/ForgeCore-main/electron/renderer/src/state/wizardStore.ts
+++ b/ForgeCore-main/ForgeCore-main/electron/renderer/src/state/wizardStore.ts
@@ -347,12 +347,19 @@ export function mergeWizardState(
   } as IncompleteMap;
 
   for (const step of WIZARD_STEP_ORDER) {
-    const restoredStep = restoredSteps[step];
-    if (restoredStep?.status === 'saving') {
-      restoredSteps[step] = {
-        ...restoredStep,
-        status: 'editing',
-      };
+    const existingStep = restoredSteps[step];
+    if (!existingStep) {
+      continue;
+    }
+
+    const sanitizedStep = {
+      ...existingStep,
+      status: existingStep.status === 'saving' ? 'editing' : existingStep.status,
+    };
+
+    restoredSteps[step] = sanitizedStep;
+
+    if (existingStep.status === 'saving') {
       restoredIncomplete[step] = true;
     }
   }


### PR DESCRIPTION
## Summary
- sanitize restored wizard steps so persisted "saving" states reopen as editable and marked incomplete
- ensure save status always reverts from "saving" even if persistence restored mid-save

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df2173cd48832ebafeb45038624323