### PR TITLE
Implement APScheduler loop and RSI patch notes ingest pipeline

### DIFF
--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/ingest/__init__.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/ingest/__init__.py
@@ -1,0 +1,7 @@
+"""Ingest pipeline helpers for Starlinker."""
+
+from .manager import IngestManager
+from .models import NormalizedSignal
+from .rsi_patch_notes import RSIPatchNotesIngest
+
+__all__ = ["IngestManager", "NormalizedSignal", "RSIPatchNotesIngest"]

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/ingest/manager.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/ingest/manager.py
@@ -1,0 +1,100 @@
+"""Coordinator for ingest modules."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Callable, Dict, Iterable, Mapping, Protocol
+
+import httpx
+
+from ..config import StarlinkerConfig
+from ..store import StarlinkerDatabase
+from .models import NormalizedSignal
+
+
+class IngestModule(Protocol):
+    """Contract implemented by ingest modules."""
+
+    name: str
+
+    def enabled(self, config: StarlinkerConfig) -> bool: ...
+
+    async def run(
+        self,
+        *,
+        config: StarlinkerConfig,
+        client: httpx.AsyncClient,
+        triggered_at: datetime,
+    ) -> Iterable[NormalizedSignal]: ...
+
+
+def _default_client_factory() -> httpx.AsyncClient:
+    headers = {"User-Agent": "Starlinker/0.1"}
+    return httpx.AsyncClient(timeout=httpx.Timeout(20.0), headers=headers)
+
+
+class IngestManager:
+    """Runs enabled ingest modules and stores their results."""
+
+    def __init__(
+        self,
+        database: StarlinkerDatabase,
+        *,
+        http_client_factory: Callable[[], httpx.AsyncClient] | None = None,
+    ) -> None:
+        self._database = database
+        self._client_factory = http_client_factory or _default_client_factory
+        self._modules: Dict[str, IngestModule] = {}
+        self._lock = asyncio.Lock()
+
+    def register_module(self, module: IngestModule) -> None:
+        self._modules[module.name] = module
+
+    @property
+    def modules(self) -> Mapping[str, IngestModule]:
+        return dict(self._modules)
+
+    async def run_poll(
+        self,
+        config: StarlinkerConfig,
+        *,
+        reason: str,
+        triggered_at: datetime,
+    ) -> Dict[str, Dict[str, int]]:
+        """Execute a poll pass across all enabled modules."""
+
+        async with self._lock:
+            return await self._run_modules(config, reason=reason, triggered_at=triggered_at)
+
+    async def _run_modules(
+        self,
+        config: StarlinkerConfig,
+        *,
+        reason: str,
+        triggered_at: datetime,
+    ) -> Dict[str, Dict[str, int]]:
+        summary: Dict[str, Dict[str, int]] = {}
+        async with self._client_factory() as client:
+            for name, module in self._modules.items():
+                if not module.enabled(config):
+                    continue
+                try:
+                    signals = [
+                        signal
+                        for signal in await module.run(
+                            config=config,
+                            client=client,
+                            triggered_at=triggered_at,
+                        )
+                    ]
+                except Exception as exc:  # pragma: no cover - defensive guard
+                    self._database.record_error(
+                        module=name,
+                        message=str(exc),
+                        details={"reason": reason},
+                    )
+                    continue
+                stored = self._database.store_signals(signals)
+                summary[name] = {"fetched": len(signals), "stored": stored}
+        return summary

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/ingest/models.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/ingest/models.py
@@ -1,0 +1,60 @@
+"""Data structures shared across ingest modules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Iterable, Sequence
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+@dataclass(slots=True)
+class NormalizedSignal:
+    """Represents a normalized content signal ready for persistence."""
+
+    source: str
+    title: str
+    url: str
+    published_at: datetime
+    fetched_at: datetime
+    raw_excerpt: str | None = None
+    summary: str | None = None
+    tags: Sequence[str] = field(default_factory=tuple)
+    priority: int = 0
+
+    def __post_init__(self) -> None:
+        self.published_at = _ensure_utc(self.published_at)
+        self.fetched_at = _ensure_utc(self.fetched_at)
+        if isinstance(self.tags, Iterable):
+            self.tags = tuple(tag for tag in self.tags if tag)
+        else:
+            self.tags = tuple()
+
+    def to_row(self) -> dict[str, object]:
+        """Serialize the signal into a SQLite-friendly mapping."""
+
+        tags_json = None
+        if self.tags:
+            tags_json = json_dumps(self.tags)
+        return {
+            "source": self.source,
+            "title": self.title,
+            "url": self.url,
+            "published_at": self.published_at.isoformat(),
+            "fetched_at": self.fetched_at.isoformat(),
+            "raw_excerpt": self.raw_excerpt,
+            "summary": self.summary,
+            "tags_json": tags_json,
+            "priority": self.priority,
+        }
+
+
+def json_dumps(value: Sequence[str]) -> str:
+    import json
+
+    return json.dumps(list(value))

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/ingest/rsi_patch_notes.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/ingest/rsi_patch_notes.py
@@ -1,0 +1,111 @@
+"""RSI Patch Notes ingest module."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List
+
+import httpx
+
+from ..config import StarlinkerConfig
+from .models import NormalizedSignal
+
+
+API_URL = "https://robertsspaceindustries.com/api/patchnotes/get"
+
+
+class RSIPatchNotesIngest:
+    """Fetch patch note releases from RSI."""
+
+    name = "rsi.patch_notes"
+
+    def enabled(self, config: StarlinkerConfig) -> bool:
+        return bool(config.sources.patch_notes.enabled)
+
+    async def run(
+        self,
+        *,
+        config: StarlinkerConfig,
+        client: httpx.AsyncClient,
+        triggered_at: datetime,
+    ) -> Iterable[NormalizedSignal]:
+        include_ptu = config.sources.patch_notes.include_ptu
+        channels = ["LIVE"] + (["PTU"] if include_ptu else [])
+        seen: set[str] = set()
+        results: List[NormalizedSignal] = []
+        for channel in channels:
+            payload = await self._fetch_channel(client, channel)
+            for item in payload:
+                normalized = self._normalize_item(item, channel=channel, fetched_at=triggered_at)
+                if normalized.url in seen:
+                    continue
+                seen.add(normalized.url)
+                results.append(normalized)
+        return results
+
+    async def _fetch_channel(
+        self, client: httpx.AsyncClient, channel: str
+    ) -> List[Dict[str, object]]:
+        params = {"page": 1, "channel": channel}
+        response = await client.get(API_URL, params=params, headers={"Accept": "application/json"})
+        response.raise_for_status()
+        data = response.json()
+        entries: List[Dict[str, object]] = []
+        if not isinstance(data, dict):
+            return entries
+        container = data.get("data")
+        if isinstance(container, dict):
+            patchnotes = container.get("patchnotes")
+        else:
+            patchnotes = None
+        if isinstance(patchnotes, list):
+            for item in patchnotes:
+                if isinstance(item, dict):
+                    entries.append(item)
+        return entries
+
+    def _normalize_item(
+        self, item: Dict[str, object], *, channel: str, fetched_at: datetime
+    ) -> NormalizedSignal:
+        title = str(item.get("title") or "Patch Notes")
+        url = self._build_url(item.get("url"))
+        published_at = self._parse_datetime(
+            item.get("published_at")
+            or item.get("time_created")
+            or item.get("created_at")
+        )
+        excerpt = item.get("excerpt") or item.get("snippet") or item.get("brief")
+        tags: List[str] = ["rsi", "patch-notes", channel.lower()]
+        if item.get("channel") and str(item.get("channel")).lower() not in tags:
+            tags.append(str(item["channel"]).lower())
+        return NormalizedSignal(
+            source=f"rsi.patch_notes.{channel.lower()}",
+            title=title.strip(),
+            url=url,
+            published_at=published_at,
+            fetched_at=fetched_at,
+            raw_excerpt=str(excerpt).strip() if excerpt else None,
+            tags=tags,
+        )
+
+    def _build_url(self, url_value: object) -> str:
+        raw = str(url_value or "").strip()
+        if raw.startswith("http://") or raw.startswith("https://"):
+            return raw
+        if not raw.startswith("/"):
+            raw = f"/{raw}" if raw else "/"
+        return f"https://robertsspaceindustries.com{raw}"
+
+    def _parse_datetime(self, value: object) -> datetime:
+        if isinstance(value, (int, float)):
+            return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        if isinstance(value, str):
+            text = value.strip()
+            for fmt in ("%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S%z"):
+                try:
+                    dt = datetime.strptime(text.replace("Z", "+00:00"), fmt)
+                except ValueError:
+                    continue
+                else:
+                    return dt.astimezone(timezone.utc) if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        return datetime.now(timezone.utc)

--- a/ForgeCore-main/ForgeCore-main/forgecore/tests/starlinker_news/test_ingest_patch_notes.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/tests/starlinker_news/test_ingest_patch_notes.py
@@ -1,0 +1,85 @@
+"""Tests for the RSI Patch Notes ingest module."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+
+import httpx
+
+from forgecore.starlinker_news.config import StarlinkerConfig
+from forgecore.starlinker_news.ingest import IngestManager, RSIPatchNotesIngest
+from forgecore.starlinker_news.store import StarlinkerDatabase
+
+
+def test_patch_notes_ingest_persists_signals(tmp_path) -> None:
+    database = StarlinkerDatabase(tmp_path / "starlinker.db")
+    database.initialize()
+    config = StarlinkerConfig()
+    config.sources.patch_notes.include_ptu = True
+    triggered_at = datetime(2024, 10, 1, 12, 0, tzinfo=timezone.utc)
+
+    live_payload = [
+        {
+            "title": "Star Citizen 3.21.0",
+            "url": "/comm-link//patch-notes/star-citizen-3-21-0",
+            "published_at": "2024-09-30T18:00:00Z",
+            "excerpt": "LIVE patch release",
+            "channel": "LIVE",
+        }
+    ]
+    ptu_payload = [
+        {
+            "title": "Star Citizen 3.21.1 PTU",
+            "url": "https://robertsspaceindustries.com/patch-notes/star-citizen-3-21-1-ptu",
+            "time_created": 1720000000,
+            "snippet": "PTU build",
+            "channel": "PTU",
+        }
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        channel = request.url.params.get("channel", "LIVE")
+        payload = live_payload if channel == "LIVE" else ptu_payload
+        return httpx.Response(200, json={"data": {"patchnotes": payload}})
+
+    transport = httpx.MockTransport(handler)
+
+    def client_factory() -> httpx.AsyncClient:
+        return httpx.AsyncClient(transport=transport)
+
+    manager = IngestManager(database, http_client_factory=client_factory)
+    manager.register_module(RSIPatchNotesIngest())
+
+    summary = asyncio.run(
+        manager.run_poll(
+            config,
+            reason="test",
+            triggered_at=triggered_at,
+        )
+    )
+
+    assert summary["rsi.patch_notes"]["stored"] == 2
+
+    with database.connect() as conn:
+        rows = conn.execute(
+            "SELECT source, title, url, tags_json FROM signals ORDER BY id"
+        ).fetchall()
+
+    assert {row["source"] for row in rows} == {
+        "rsi.patch_notes.live",
+        "rsi.patch_notes.ptu",
+    }
+    tags_sets = [set(json.loads(row["tags_json"])) for row in rows]
+    for tags in tags_sets:
+        assert "rsi" in tags and "patch-notes" in tags
+
+    repeat = asyncio.run(
+        manager.run_poll(
+            config,
+            reason="repeat",
+            triggered_at=triggered_at,
+        )
+    )
+    assert repeat["rsi.patch_notes"]["stored"] == 0

--- a/ForgeCore-main/ForgeCore-main/requirements.txt
+++ b/ForgeCore-main/ForgeCore-main/requirements.txt
@@ -5,4 +5,5 @@ fastapi>=0.103.0
 uvicorn>=0.21.0
 pydantic>=2.0
 httpx>=0.24.1
+apscheduler>=3.10.4
 pytest>=7.0.0

--- a/ForgeCore-main/ForgeCore-main/setup.py
+++ b/ForgeCore-main/ForgeCore-main/setup.py
@@ -12,6 +12,7 @@ setup(
         "uvicorn>=0.21.0",
         "pydantic>=2.0",
         "httpx>=0.24.1",
+        "apscheduler>=3.10.4",
     ],
     extras_require={
         "dev": ["pytest>=7.0.0"],


### PR DESCRIPTION
## Summary
- replace the timer-based scheduler with an APScheduler-driven async service that calls the ingest manager
- wire up a shared ingest manager with an RSI patch notes module and SQLite helpers for normalized signals
- add tests covering scheduler triggers and the end-to-end patch notes pipeline while bringing in APScheduler

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df32c4a1c4832e83560162f6915533