### PR TITLE
Add Starlinker alerts and digest pipeline

### DIFF
--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/__init__.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/__init__.py
@@ -1,7 +1,15 @@
 """Starlinker News backend package."""
 
+from .alerts import AlertsService, DigestService
 from .api import create_app
 from .backend import StarlinkerBackend
 from .config import StarlinkerConfig, THEME_SLUGS
 
-__all__ = ["create_app", "StarlinkerBackend", "StarlinkerConfig", "THEME_SLUGS"]
+__all__ = [
+    "AlertsService",
+    "DigestService",
+    "create_app",
+    "StarlinkerBackend",
+    "StarlinkerConfig",
+    "THEME_SLUGS",
+]

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/alerts.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/alerts.py
@@ -1,0 +1,319 @@
+"""Alert and digest services for Starlinker."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timedelta, time, timezone
+from typing import Callable, List, Optional
+
+import httpx
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from .config import StarlinkerConfig
+from .store import StarlinkerDatabase, StoredSignal
+
+
+@dataclass
+class AlertCandidate:
+    signal: StoredSignal
+    priority: int
+    dedup_key: str
+
+
+class EmailSenderProtocol:
+    """Protocol-like shim for sending email placeholders."""
+
+    def send(self, to: str, subject: str, body: str) -> None:  # pragma: no cover - protocol helper
+        raise NotImplementedError
+
+
+class EmailPlaceholder(EmailSenderProtocol):
+    """Simple in-memory placeholder for email delivery."""
+
+    def __init__(self) -> None:
+        self.sent: List[dict[str, str]] = []
+
+    def send(self, to: str, subject: str, body: str) -> None:
+        self.sent.append({"to": to, "subject": subject, "body": body})
+
+
+class AlertsService:
+    """Evaluate stored signals, dedupe and dispatch alerts."""
+
+    def __init__(
+        self,
+        database: StarlinkerDatabase,
+        *,
+        http_client_factory: Callable[[], httpx.AsyncClient] | None = None,
+        mailer: Optional[EmailSenderProtocol] = None,
+        clock: Optional[Callable[[], datetime]] = None,
+        window_hours: int = 24,
+        min_priority: int = 60,
+    ) -> None:
+        self._database = database
+        self._http_client_factory = http_client_factory or self._default_client_factory
+        self._mailer = mailer or EmailPlaceholder()
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._window = timedelta(hours=window_hours)
+        self._min_priority = min_priority
+        self._lock = asyncio.Lock()
+
+    async def run(self, config: StarlinkerConfig, *, triggered_at: datetime) -> dict[str, object]:
+        async with self._lock:
+            return await self._run_locked(config, triggered_at=triggered_at)
+
+    async def _run_locked(self, config: StarlinkerConfig, *, triggered_at: datetime) -> dict[str, object]:
+        candidates = self._collect_candidates(config, triggered_at=triggered_at)
+        if not candidates:
+            return {"alerts": 0, "suppressed": False}
+        if self._in_quiet_hours(config, triggered_at):
+            return {"alerts": 0, "suppressed": True}
+
+        delivered_total = 0
+        async with self._http_client_factory() as client:
+            for candidate in candidates:
+                delivered_channels: List[str] = []
+                content = self._render_message(candidate)
+                subject = f"[Starlinker] {candidate.signal.title}"
+                webhook = config.outputs.discord_webhook.strip()
+                if webhook:
+                    try:
+                        await self._post_discord(client, webhook, content)
+                        delivered_channels.append("discord")
+                    except Exception as exc:  # pragma: no cover - defensive
+                        self._database.record_error(
+                            module="alerts.dispatch",
+                            message=str(exc),
+                            details={"channel": "discord"},
+                        )
+                email_to = config.outputs.email_to.strip()
+                if email_to:
+                    try:
+                        self._mailer.send(email_to, subject, content)
+                        delivered_channels.append("email")
+                    except Exception as exc:  # pragma: no cover - defensive
+                        self._database.record_error(
+                            module="alerts.dispatch",
+                            message=str(exc),
+                            details={"channel": "email"},
+                        )
+                if delivered_channels:
+                    self._database.record_alert(
+                        alert_type="signal",
+                        title=candidate.signal.title,
+                        url=candidate.signal.url,
+                        delivered_channels=delivered_channels,
+                        dedup_key=candidate.dedup_key,
+                        created_at=triggered_at,
+                    )
+                    delivered_total += 1
+        return {"alerts": delivered_total, "suppressed": False}
+
+    # Candidate helpers -------------------------------------------------
+
+    def _collect_candidates(
+        self, config: StarlinkerConfig, *, triggered_at: datetime
+    ) -> List[AlertCandidate]:
+        since = triggered_at - self._window
+        signals = self._database.fetch_signals(since=since)
+        candidates: List[AlertCandidate] = []
+        for signal in signals:
+            priority = self._score_signal(signal)
+            if priority < self._min_priority:
+                continue
+            dedup_key = self._build_dedup_key(signal)
+            if self._database.alert_exists(dedup_key):
+                continue
+            candidates.append(AlertCandidate(signal=signal, priority=priority, dedup_key=dedup_key))
+        candidates.sort(key=lambda item: (item.priority, item.signal.published_at), reverse=True)
+        return candidates
+
+    def _score_signal(self, signal: StoredSignal) -> int:
+        priority = int(signal.priority or 0)
+        tags = {tag.lower() for tag in signal.tags}
+        if "live" in tags:
+            priority = max(priority, 80)
+        if "ptu" in tags:
+            priority = max(priority, 50)
+        lowered = signal.title.lower()
+        if "hotfix" in lowered or "critical" in lowered:
+            priority = max(priority, 85)
+        if "roadmap" in lowered or "status" in lowered:
+            priority = max(priority, 60)
+        return priority
+
+    def _build_dedup_key(self, signal: StoredSignal) -> str:
+        return f"{signal.source}:{signal.url.lower()}"
+
+    def _render_message(self, candidate: AlertCandidate) -> str:
+        signal = candidate.signal
+        summary = signal.summary or signal.raw_excerpt or ""
+        published = signal.published_at.astimezone(ZoneInfo("UTC")).strftime("%Y-%m-%d %H:%M UTC")
+        lines = [
+            f"**{signal.title}**",
+            f"Source: {signal.source}",
+            f"Published: {published}",
+            signal.url,
+        ]
+        if summary:
+            lines.append("")
+            lines.append(summary.strip())
+        return "\n".join(lines)
+
+    def _in_quiet_hours(self, config: StarlinkerConfig, moment: datetime) -> bool:
+        if not config.quiet_hours or len(config.quiet_hours) != 2:
+            return False
+        try:
+            tz = ZoneInfo(config.timezone)
+        except ZoneInfoNotFoundError:
+            tz = ZoneInfo("UTC")
+        local = moment.astimezone(tz)
+        start = self._parse_time(config.quiet_hours[0])
+        end = self._parse_time(config.quiet_hours[1])
+        current = local.time()
+        if start <= end:
+            return start <= current < end
+        return current >= start or current < end
+
+    def _parse_time(self, value: str) -> time:
+        hours, minutes = value.split(":", 1)
+        return time(hour=int(hours), minute=int(minutes))
+
+    async def _post_discord(self, client: httpx.AsyncClient, url: str, content: str) -> None:
+        payload = {"content": content[:1800]}
+        response = await client.post(url, json=payload)
+        response.raise_for_status()
+
+    @staticmethod
+    def _default_client_factory() -> httpx.AsyncClient:
+        headers = {"User-Agent": "Starlinker/0.1"}
+        timeout = httpx.Timeout(20.0)
+        return httpx.AsyncClient(timeout=timeout, headers=headers)
+
+
+class DigestService:
+    """Generate digests from stored signals and dispatch them."""
+
+    def __init__(
+        self,
+        database: StarlinkerDatabase,
+        *,
+        http_client_factory: Callable[[], httpx.AsyncClient] | None = None,
+        mailer: Optional[EmailSenderProtocol] = None,
+        clock: Optional[Callable[[], datetime]] = None,
+    ) -> None:
+        self._database = database
+        self._http_client_factory = http_client_factory or AlertsService._default_client_factory
+        self._mailer = mailer or EmailPlaceholder()
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._lock = asyncio.Lock()
+
+    async def run_digest(
+        self,
+        digest_type: str,
+        config: StarlinkerConfig,
+        *,
+        triggered_at: datetime,
+    ) -> dict[str, object]:
+        async with self._lock:
+            return await self._run_locked(digest_type, config, triggered_at=triggered_at)
+
+    async def _run_locked(
+        self,
+        digest_type: str,
+        config: StarlinkerConfig,
+        *,
+        triggered_at: datetime,
+    ) -> dict[str, object]:
+        body, signals = self.generate_digest_body(digest_type, config, triggered_at=triggered_at)
+        if not signals:
+            return {"digest": digest_type, "sent": False, "signals": 0}
+        subject = f"[Starlinker] {digest_type.title()} Digest"
+        delivered_channels: List[str] = []
+        async with self._http_client_factory() as client:
+            webhook = config.outputs.discord_webhook.strip()
+            if webhook:
+                try:
+                    await client.post(webhook, json={"content": body[:1800]})
+                    delivered_channels.append("discord")
+                except Exception as exc:  # pragma: no cover - defensive
+                    self._database.record_error(
+                        module="digest.dispatch",
+                        message=str(exc),
+                        details={"channel": "discord"},
+                    )
+            email_to = config.outputs.email_to.strip()
+            if email_to:
+                try:
+                    self._mailer.send(email_to, subject, body)
+                    delivered_channels.append("email")
+                except Exception as exc:  # pragma: no cover - defensive
+                    self._database.record_error(
+                        module="digest.dispatch",
+                        message=str(exc),
+                        details={"channel": "email"},
+                    )
+        if delivered_channels:
+            self._database.record_digest(
+                digest_type=digest_type,
+                body_markdown=body,
+                sent_at=triggered_at,
+            )
+        return {
+            "digest": digest_type,
+            "sent": bool(delivered_channels),
+            "signals": len(signals),
+            "channels": delivered_channels,
+        }
+
+    def generate_digest_body(
+        self,
+        digest_type: str,
+        config: StarlinkerConfig,
+        *,
+        triggered_at: Optional[datetime] = None,
+    ) -> tuple[str, List[StoredSignal]]:
+        window = self._window_for(digest_type)
+        moment = triggered_at or self._clock()
+        since = moment - window
+        signals = self._database.fetch_signals(since=since)
+        if not signals:
+            return ("", [])
+        try:
+            tz = ZoneInfo(config.timezone)
+        except ZoneInfoNotFoundError:
+            tz = ZoneInfo("UTC")
+        local_date = moment.astimezone(tz).strftime("%Y-%m-%d")
+        header = f"# Starlinker {digest_type.title()} Digest ({local_date})"
+        lines = [header, ""]
+        for signal in sorted(
+            signals,
+            key=lambda item: (item.priority, item.published_at),
+            reverse=True,
+        ):
+            published = signal.published_at.astimezone(tz).strftime("%Y-%m-%d %H:%M")
+            lines.append(f"- [{signal.title}]({signal.url}) — {published}")
+            summary = signal.summary or signal.raw_excerpt
+            if summary:
+                lines.append(f"  - {summary.strip()[:280]}")
+        body = "\n".join(lines)
+        return body, signals
+
+    def preview(
+        self,
+        digest_type: str,
+        config: StarlinkerConfig,
+        *,
+        triggered_at: Optional[datetime] = None,
+    ) -> dict[str, object]:
+        body, signals = self.generate_digest_body(digest_type, config, triggered_at=triggered_at)
+        return {"digest": digest_type, "body": body, "signals": len(signals)}
+
+    def _window_for(self, digest_type: str) -> timedelta:
+        if digest_type == "daily":
+            return timedelta(days=1)
+        if digest_type == "weekly":
+            return timedelta(days=7)
+        raise ValueError(f"Unsupported digest type: {digest_type}")
+

--- a/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/api.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/starlinker_news/api.py
@@ -6,7 +6,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Optional
 
-from fastapi import Body, FastAPI, HTTPException
+from fastapi import Body, FastAPI, HTTPException, Query
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field, ValidationError
 
@@ -86,6 +86,10 @@ def create_app(
     @app.post("/run/digest")
     async def run_digest(request: DigestRequest) -> dict:
         return backend.scheduler.trigger_digest(request.type)
+
+    @app.get("/digest/preview")
+    async def preview_digest(digest_type: str = Query("daily")) -> dict[str, object]:
+        return backend.preview_digest(digest_type)
 
     @app.get("/appearance/themes")
     async def list_themes() -> dict:

--- a/ForgeCore-main/ForgeCore-main/forgecore/tests/starlinker_news/test_alerts_digest.py
+++ b/ForgeCore-main/ForgeCore-main/forgecore/tests/starlinker_news/test_alerts_digest.py
@@ -1,0 +1,162 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from forgecore.starlinker_news.alerts import AlertsService, DigestService, EmailPlaceholder
+from forgecore.starlinker_news.config import StarlinkerConfig
+from forgecore.starlinker_news.ingest.models import NormalizedSignal
+from forgecore.starlinker_news.store import StarlinkerDatabase
+
+
+class DummyClient:
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, json):
+        self._recorder.append({"url": url, "json": json})
+
+        class Response:
+            status_code = 204
+
+            def raise_for_status(self):
+                return None
+
+        return Response()
+
+
+class DummyClientFactory:
+    def __init__(self):
+        self.requests: list[dict] = []
+
+    def __call__(self):
+        return DummyClient(self.requests)
+
+
+@pytest.fixture()
+def config() -> StarlinkerConfig:
+    cfg = StarlinkerConfig()
+    cfg.outputs.discord_webhook = "https://hooks.example"
+    cfg.outputs.email_to = "ops@example"
+    cfg.quiet_hours = ["00:00", "00:01"]
+    return cfg
+
+
+def _store_signal(db: StarlinkerDatabase, *, priority: int = 80) -> None:
+    now = datetime.now(timezone.utc)
+    signal = NormalizedSignal(
+        source="rsi.patch_notes.live",
+        title="LIVE Patch Released",
+        url="https://example.com/patch",
+        published_at=now - timedelta(minutes=5),
+        fetched_at=now - timedelta(minutes=1),
+        raw_excerpt="Patch notes summary",
+        tags=("rsi", "live"),
+        priority=priority,
+    )
+    db.store_signals([signal])
+
+
+def test_alerts_service_respects_quiet_hours(tmp_path, config):
+    database = StarlinkerDatabase(tmp_path / "starlinker.db")
+    database.initialize()
+    _store_signal(database)
+    cfg = config
+    cfg.quiet_hours = ["00:00", "23:59"]
+    client_factory = DummyClientFactory()
+    mailer = EmailPlaceholder()
+    service = AlertsService(
+        database,
+        http_client_factory=client_factory,
+        mailer=mailer,
+    )
+    triggered_at = datetime(2024, 1, 1, 12, tzinfo=timezone.utc)
+
+    result = asyncio.run(service.run(cfg, triggered_at=triggered_at))
+
+    assert result["suppressed"] is True
+    assert database.list_alerts() == []
+    assert client_factory.requests == []
+    assert mailer.sent == []
+
+
+def test_alerts_service_dispatches_and_dedupes(tmp_path, config):
+    database = StarlinkerDatabase(tmp_path / "starlinker.db")
+    database.initialize()
+    _store_signal(database)
+    cfg = config
+    cfg.quiet_hours = ["23:00", "23:30"]
+    client_factory = DummyClientFactory()
+    mailer = EmailPlaceholder()
+    service = AlertsService(
+        database,
+        http_client_factory=client_factory,
+        mailer=mailer,
+    )
+    triggered_at = datetime(2024, 1, 1, 6, tzinfo=timezone.utc)
+
+    first = asyncio.run(service.run(cfg, triggered_at=triggered_at))
+    second = asyncio.run(
+        service.run(cfg, triggered_at=triggered_at + timedelta(minutes=10))
+    )
+
+    assert first["alerts"] == 1
+    assert second["alerts"] == 0
+    assert len(database.list_alerts()) == 1
+    assert len(client_factory.requests) == 1
+    assert len(mailer.sent) == 1
+
+
+def test_digest_service_generates_markdown_and_records(tmp_path, config):
+    database = StarlinkerDatabase(tmp_path / "starlinker.db")
+    database.initialize()
+    now = datetime(2024, 1, 1, 12, tzinfo=timezone.utc)
+    recent = NormalizedSignal(
+        source="rsi.patch_notes.live",
+        title="LIVE Patch",
+        url="https://example.com/live",
+        published_at=now - timedelta(hours=3),
+        fetched_at=now - timedelta(hours=1),
+        raw_excerpt="Important changes",
+        tags=("live",),
+        priority=80,
+    )
+    older = NormalizedSignal(
+        source="rsi.patch_notes.ptu",
+        title="PTU Update",
+        url="https://example.com/ptu",
+        published_at=now - timedelta(days=2),
+        fetched_at=now - timedelta(days=2),
+        raw_excerpt="PTU details",
+        tags=("ptu",),
+        priority=40,
+    )
+    database.store_signals([recent, older])
+
+    cfg = config
+    cfg.quiet_hours = ["23:00", "23:30"]
+    client_factory = DummyClientFactory()
+    mailer = EmailPlaceholder()
+    service = DigestService(
+        database,
+        http_client_factory=client_factory,
+        mailer=mailer,
+    )
+
+    result = asyncio.run(service.run_digest("daily", cfg, triggered_at=now))
+    preview = service.preview("daily", cfg, triggered_at=now)
+
+    assert result["sent"] is True
+    assert result["signals"] == 1
+    assert len(database.list_digests()) == 1
+    assert "LIVE Patch" in preview["body"]
+    assert "PTU" not in preview["body"]
+    assert len(client_factory.requests) == 1
+    assert len(mailer.sent) == 1
+


### PR DESCRIPTION
## Summary
- add alert and digest services with quiet hours handling, dedupe, and Discord/email dispatchers
- integrate the scheduler, backend, and API to trigger digests and expose a preview endpoint
- extend persistence utilities, ingest priority scoring, and add coverage for alert and digest flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0362dd834832eabc180180fcde100