### PR TITLE
Handle failed theme saves in appearance tab

### DIFF
--- a/ForgeCore-main/ForgeCore-main/electron/renderer/src/pages/AdminConsole.tsx
+++ b/ForgeCore-main/ForgeCore-main/electron/renderer/src/pages/AdminConsole.tsx
@@ -1108,14 +1108,18 @@ function AppearanceTab({ config, disabled, onSave, validationIssues }: TabProps)
   }, []);
 
   const handleThemeChange = async (value: string) => {
+    const previous = selected;
     setSelected(value);
-    await onSave(
+    const success = await onSave(
       { appearance: { theme: value } },
       {
         success: 'Theme updated',
         error: 'Failed to update theme',
       },
     );
+    if (!success) {
+      setSelected(previous);
+    }
   };
 
   const handleAutoLaunchToggle = async () => {


### PR DESCRIPTION
## Summary
- restore the previous theme selection when a theme save fails
- only keep the new theme value after a successful save request

## Testing
- Not run (manual testing required separately)


------
https://chatgpt.com/codex/tasks/task_e_68e04a8fac80832ea25ced1fb1ef1889